### PR TITLE
scraper fix

### DIFF
--- a/server/src/scraper.js
+++ b/server/src/scraper.js
@@ -11,7 +11,7 @@ class Scraper {
     const $recipe = $body.find('.ccm-wrapper')
     const $ingredients = $body.find('.ccm-section-ingredients')
     const $directions = $body.find('.ccm-section-instructions')
-    
+        
     const Recipe = {}
     
     Recipe.name = $recipe.find('.ccm-name').text()
@@ -24,7 +24,9 @@ class Scraper {
       const ingredientList = $(element).find('span')
       ingredientList.each((index, element) => {
         const ingredient = $(element).text()
-        Recipe.ingredients.push(ingredient)
+        if (isNaN(ingredient)) {
+          Recipe.ingredients.push(ingredient)
+        }
       })
     })
     
@@ -39,7 +41,5 @@ class Scraper {
     return Recipe
   }
 }
-
-// console.log(Recipe)
 
 export default Scraper


### PR DESCRIPTION
scraper for ethan chlebowski's site had a weird bug where, if the recipe has the "yield" option to scale up or down the ingredients, the scraped ingredients would include extra integer values corresponding to the amount of a given ingredient ie ['2 chicken breast', 2, '200g milk', 200, '1 egg', 1, etc].

added a isNaN() check for each ingredient to prevent pushing the extra integers to the recipe ingredients array